### PR TITLE
Handle Statement with Rewards Points cashed in

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 
         end := len(body)
 	if loc := findEnd.FindIndex(body); loc != nil {
-            end = loc[0]
+		end = loc[0]
         }
 	sts := findStatements.FindAllSubmatch(body[0:end], -1)
 	log.Printf("Found %d matches\n", len(sts))

--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ func (s *Statement) Reconcile() (float64, bool) {
 
 var findStatements = regexp.MustCompile(`(?m)^([0-9]{0,2})/([0-9]{0,2}) (.*) ([0-9\-\.,]+)`)
 
+var findEnd = regexp.MustCompile(`Amount Rewards`)
+
 var (
 	findPreviousBalance = regexp.MustCompile(`(?m)^Previous Balance \$([0-9\-\.,]+)`)
 	findNewBalance      = regexp.MustCompile(`(?m)^New Balance \$([0-9\-\.,]+)`)
@@ -117,7 +119,11 @@ func main() {
 		yearBytes = yb[1]
 	}
 
-	sts := findStatements.FindAllSubmatch(body, -1)
+        end := len(body)
+	if loc := findEnd.FindIndex(body); loc != nil {
+            end = loc[0]
+        }
+	sts := findStatements.FindAllSubmatch(body[0:end], -1)
 	log.Printf("Found %d matches\n", len(sts))
 	for i, st := range sts {
 		if len(st) < 4 {

--- a/main.go
+++ b/main.go
@@ -119,10 +119,10 @@ func main() {
 		yearBytes = yb[1]
 	}
 
-        end := len(body)
+	end := len(body)
 	if loc := findEnd.FindIndex(body); loc != nil {
 		end = loc[0]
-        }
+	}
 	sts := findStatements.FindAllSubmatch(body[0:end], -1)
 	log.Printf("Found %d matches\n", len(sts))
 	for i, st := range sts {


### PR DESCRIPTION
This worked well, even in the cases it didn't!

In the 2 statements where it failed, it tripped up on your reconciliation check. Otherwise I might not have noticed any issue.

The fix I did was to look for some words in the heading before the rewards data gets printed, and call that the end of the statement body when looking for transactions.

Seems to work. At least it passed your reconciliation test!